### PR TITLE
Building mpy-cross under WINDOWS & cygwin fails

### DIFF
--- a/mpy-cross/Makefile
+++ b/mpy-cross/Makefile
@@ -9,6 +9,7 @@ override undefine FROZEN_DIR
 override undefine FROZEN_MPY_DIR
 override undefine BUILD
 override undefine PROG
+override undefine PROG_BIN
 endif
 
 include ../py/mkenv.mk
@@ -66,6 +67,9 @@ SRC_C = \
 COMPILER_TARGET := $(shell $(CC) -dumpmachine)
 ifneq (,$(findstring mingw,$(COMPILER_TARGET)))
 	SRC_C += ports/windows/fmode.c
+	PROG_BIN = $(PROG).exe
+else
+	PROG_BIN = $(PROG)
 endif
 
 OBJ = $(PY_O)

--- a/py/mkenv.mk
+++ b/py/mkenv.mk
@@ -59,7 +59,12 @@ LD += -m32
 endif
 
 MAKE_FROZEN = $(TOP)/tools/make-frozen.py
+# allow mpy-cross (for WSL) and mpy-cross.exe (for cygwin) to coexist
+ifeq ($(OS),Windows_NT)
+MPY_CROSS = $(TOP)/mpy-cross/mpy-cross.exe
+else
 MPY_CROSS = $(TOP)/mpy-cross/mpy-cross
+endif
 MPY_TOOL = $(TOP)/tools/mpy-tool.py
 
 all:

--- a/py/mkrules.mk
+++ b/py/mkrules.mk
@@ -133,13 +133,13 @@ $(PROG): $(OBJ)
 # we may want to compile using Thumb, but link with non-Thumb libc.
 	$(Q)$(CC) -o $@ $^ $(LIB) $(LDFLAGS)
 ifndef DEBUG
-	$(Q)$(STRIP) $(STRIPFLAGS_EXTRA) $(PROG)
+	$(Q)$(STRIP) $(STRIPFLAGS_EXTRA) $(PROG_BIN)
 endif
-	$(Q)$(SIZE) $$(find $(BUILD) -path "$(BUILD)/build/frozen*.o") $(PROG)
+	$(Q)$(SIZE) $$(find $(BUILD) -path "$(BUILD)/build/frozen*.o") $(PROG_BIN)
 
 clean: clean-prog
 clean-prog:
-	$(RM) -f $(PROG)
+	$(RM) -f $(PROG_BIN)
 	$(RM) -f $(PROG).map
 
 .PHONY: clean-prog


### PR DESCRIPTION
Building mpy-cross under WINDOWS & cygwin fails because STRIP, SIZE and RM expect to be passed a .exe file.

Use mpy-cross.exe instead of mpy-cross for the binary name in WINDOWS.

Allow mpy-cross.exe and mpy-cross to coexist so you can use cygwin and WSL without rebuilding mpy-cross.

